### PR TITLE
fix: add build dep lprotobuf and change greptime-proto to main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 cmake-build-debug
+
+.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "contrib/greptime-proto"]
 	path = contrib/greptime-proto
-	url = https://github.com/v0y4g3r/greptime-proto.git
-    branch = feat/cmake
+	url = https://github.com/GreptimeTeam/greptime-proto.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,10 @@ project(greptimedb_client_lib)
 
 file(GLOB_RECURSE OUTPUT_SOURCES "*.h" "*.cpp")
 
+include(FindProtobuf)
+find_package(Protobuf REQUIRED)
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
 add_library(${PROJECT_NAME} ${OUTPUT_SOURCES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${GREPTIMEDB_ROOT_DIR})
@@ -24,5 +28,5 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${GREPTIMEDB_ROOT_DIR})
 set(CONTRIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/contrib/greptime-proto/c++)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CONTRIB_DIR})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC greptime-proto-cpp)
+target_link_libraries(${PROJECT_NAME} PUBLIC greptime-proto-cpp protobuf)
 


### PR DESCRIPTION
This PR:
- reset greptime-proto submodule to latest main branch
- link to lprotobuf

This PR breaks build in that it introduces gRPC service stub in protos but does not links to libgrpc++.