### PR TITLE
perf: swap replaces CopyFrom to avoid excessive copying

### DIFF
--- a/examples/client_stream.cpp
+++ b/examples/client_stream.cpp
@@ -92,7 +92,7 @@ auto to_insert_request(std::vector<WeatherRecord> records) -> InsertRequest {
         for (const auto &record:records) {
             values->add_ts_millisecond_values(record.timestamp_millis);
         }
-        insert_request.add_columns()->CopyFrom(column);
+        insert_request.add_columns()->Swap(&column);
     }
 
    {
@@ -105,7 +105,7 @@ auto to_insert_request(std::vector<WeatherRecord> records) -> InsertRequest {
         for (const auto &record:records) {
             values->add_string_values(record.collector);
         }
-        insert_request.add_columns()->CopyFrom(column);
+        insert_request.add_columns()->Swap(&column);
     } 
 
     {
@@ -118,7 +118,7 @@ auto to_insert_request(std::vector<WeatherRecord> records) -> InsertRequest {
         for (const auto &record:records) {
             values->add_f32_values(record.temperature);
         }
-        insert_request.add_columns()->CopyFrom(column);
+        insert_request.add_columns()->Swap(&column);
     }
 
     {
@@ -131,7 +131,7 @@ auto to_insert_request(std::vector<WeatherRecord> records) -> InsertRequest {
         for (const auto &record:records) {
             values->add_i32_values(record.humidity);
         }
-        insert_request.add_columns()->CopyFrom(column);
+        insert_request.add_columns()->Swap(&column);
     }
 
     return insert_request;
@@ -145,7 +145,6 @@ auto to_insert_requests(const std::vector<InsertRequest>& vec_insert_requests) -
     }
     return insert_requests;
 }
-
 
 int main(int argc, char** argv) {
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -24,13 +24,13 @@ Database::Database(String dbname_, std::shared_ptr<Channel> channel_)
 
 } 
 
-bool Database::Insert(InsertRequests insert_requests) {
+bool Database::Insert(InsertRequests &insert_requests) {
     RequestHeader request_header;
     request_header.set_dbname(dbname);
     GreptimeRequest greptime_request;
-    greptime_request.mutable_header()->CopyFrom(request_header);
-    greptime_request.mutable_inserts()->CopyFrom(insert_requests);
-
+    greptime_request.mutable_header()->Swap(&request_header);
+    greptime_request.mutable_inserts()->Swap(&insert_requests);
+    
     return client.Write(greptime_request);
 }
 

--- a/src/database.h
+++ b/src/database.h
@@ -28,7 +28,7 @@ using greptime::v1::InsertRequests;
 class Database {
 public:
     Database(String dbname_, std::shared_ptr<Channel> channel);
-    bool Insert(InsertRequests insert_requests);
+    bool Insert(InsertRequests &insert_requests);
 
     bool InsertsDone() {
         return client.WritesDone();


### PR DESCRIPTION
CopyFrom takes a long time to construct Column, swap is used instead to reduce replication operations

### CopyFrom
![out_4e](https://github.com/GreptimeTeam/greptimedb-client-cpp/assets/112298607/b771c504-1bcf-48e9-8226-d6de91f5a5de)

Function: greptime:: Database: :Insert (6,289,492,430 samples, 30.33%）

### swap
![out_swap](https://github.com/GreptimeTeam/greptimedb-client-cpp/assets/112298607/1dfb8629-1c92-47ed-851e-0ef83aae0252)

Function: greptime:: Database::Insert (5,424,119,021 samples, 14.72%）
